### PR TITLE
Add GROQ API key env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_GROQ_API_KEY=<your-groq-api-key>

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Create a `.env` file based on `.env.example` and provide your Supabase credentia
 ```
 VITE_SUPABASE_URL=<your-supabase-url>
 VITE_SUPABASE_ANON_KEY=<your-anon-key>
+VITE_GROQ_API_KEY=<your-groq-api-key>
 ```
 
 ## Features


### PR DESCRIPTION
## Summary
- add `VITE_GROQ_API_KEY` placeholder to `.env.example`
- document `VITE_GROQ_API_KEY` in README

## Testing
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68553c01c57c8329a0f5df4549557e04