### PR TITLE
Fix sign-up redirect

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -60,7 +60,15 @@ const Auth = () => {
     if (error) {
       toast({ title: error.message });
     } else {
-      navigate("/dashboard");
+      const { error: signInError } = await supabase.auth.signInWithPassword({
+        email: signUpEmail,
+        password: signUpPassword,
+      });
+      if (signInError) {
+        toast({ title: signInError.message });
+      } else {
+        navigate("/dashboard");
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- ensure newly created accounts can access the dashboard immediately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855b7d2aecc8329a8f2159e277c0dbb